### PR TITLE
feat: support passing in client options

### DIFF
--- a/src/cxp/controller.ts
+++ b/src/cxp/controller.ts
@@ -177,12 +177,17 @@ function environmentFilter(
  */
 export function createController<S extends ConfigurationSubject, C = Settings>(
     context: Context<S, C>,
-    createMessageTransports: (extension: CXPExtensionWithManifest, options: ClientOptions) => Promise<MessageTransports>
+    createMessageTransports: (
+        extension: CXPExtensionWithManifest,
+        options: ClientOptions
+    ) => Promise<MessageTransports>,
+    clientOptions: Partial<ClientOptions>
 ): Controller<CXPExtensionWithManifest> {
     const controller = new Controller({
         clientOptions: (key: ClientKey, options: ClientOptions, extension: CXPExtensionWithManifest) => {
             const errorHandler = new ErrorHandler(extension.id)
             return {
+                ...clientOptions,
                 createMessageTransports: () => createMessageTransports(extension, options),
                 initializationFailedHandler: err => errorHandler.initializationFailed(err),
                 errorHandler,


### PR DESCRIPTION
This allows the client to pass in options such as callbacks (e.g. for xfiles/xcontent https://github.com/sourcegraph/cxp-js/pull/17)

On the client side:

```typescript
export const CXP_CONTROLLER = createCXPController(
    CXP_EXTENSIONS_CONTEXT_CONTROLLER.context,
    createMessageTransports,
    { files: { xfiles: ..., xcontent: ... } } // callbacks to handle file list and content requests
)
```

On the server side:

```typescript
connection.sendRequest(XContentRequest.type, { textDocument: { uri: 'someuri' } }).then(...)
```