### PR TITLE
fix: better warning message for deleted extension

### DIFF
--- a/src/cxp/controller.ts
+++ b/src/cxp/controller.ts
@@ -141,9 +141,7 @@ function environmentFilter<S extends ConfigurationSubject, CC extends Configurat
                         return false
                     } else if (!x.manifest) {
                         console.warn(
-                            `Extension ${
-                                x.id
-                            } was not found on your primary Sourcegraph instance so it will not be activated.`
+                            `Extension ${x.id} was not found. Remove it from settings to suppress this warning.`
                         )
                         return false
                     } else if (isErrorLike(x.manifest)) {


### PR DESCRIPTION
A deleted extension might still live in some users' settings. This message clarifies what users should do in this case.

See context in Slack at https://sourcegraph.slack.com/archives/C07KZF47K/p1534106118000002.