### PR TITLE
feat(ui): add action item class and list class

### DIFF
--- a/src/app/actions/ActionsNavItems.tsx
+++ b/src/app/actions/ActionsNavItems.tsx
@@ -37,13 +37,14 @@ export class ActionsNavItems<S extends ConfigurationSubject, C extends Settings>
         return (
             <>
                 {getContributedActionItems(this.state.contributions, this.props.menu).map((item, i) => (
-                    <li key={i} className="nav-item">
+                    <li key={i} className={this.props.listClass || 'nav-item'}>
                         <ActionItem
                             key={i}
                             {...item}
                             variant="actionItem"
                             cxpController={this.props.cxpController}
                             extensions={this.props.extensions}
+                            className={this.props.actionItemClass}
                         />
                     </li>
                 ))}

--- a/src/app/actions/actions.ts
+++ b/src/app/actions/actions.ts
@@ -7,6 +7,8 @@ export interface ActionsProps<S extends ConfigurationSubject, C extends Settings
     extends CXPControllerProps<S, C>,
         ExtensionsProps<S, C> {
     menu: ContributableMenu
+    actionItemClass?: string
+    listClass?: string
 }
 
 export interface ActionsState {

--- a/src/ui/generic/LinkOrButton.tsx
+++ b/src/ui/generic/LinkOrButton.tsx
@@ -40,6 +40,7 @@ export class LinkOrButton extends React.PureComponent<Props> {
         const commonProps = {
             className,
             'data-tooltip': this.props['data-tooltip'],
+            'aria-label': this.props['data-tooltip'],
             tabIndex: 0,
             onClick: this.onAnchorClick,
             onKeyPress: this.onAnchorKeyPress,


### PR DESCRIPTION
Adds ability to specify the aria-label for hovers on code hosts and also allows specifying classnames for the button group so that actions on other code hosts look clickable.

![screenshot 2018-08-23 14 38 49](https://user-images.githubusercontent.com/4897310/44553423-45488380-a6e2-11e8-81ca-7db03370e521.png)
