### PR TITLE
fix: make extension boxes stretch to be same height

### DIFF
--- a/src/extensions/manager/ExtensionCard.css
+++ b/src/extensions/manager/ExtensionCard.css
@@ -1,6 +1,7 @@
 .card.extension-card {
     min-height: 9rem;
     background-color: var(--extension-card-bg);
+    flex: 1;
 }
 
 .extension-card .extension-card-body-title {

--- a/src/extensions/manager/ExtensionCard.tsx
+++ b/src/extensions/manager/ExtensionCard.tsx
@@ -30,7 +30,7 @@ export class ExtensionCard<S extends ConfigurationSubject, C extends Settings> e
     public render(): JSX.Element | null {
         const { node, ...props } = this.props
         return (
-            <div className="col-sm-6 col-md-6 col-lg-4 pb-4">
+            <div className="d-flex col-sm-6 col-md-6 col-lg-4 pb-4">
                 <div className="extension-card card">
                     <LinkOrSpan
                         to={node.registryExtension && node.registryExtension.url}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/12925. 

I tested on Chrome and Firefox. Could not get the linking to work with the webapp, but made the equivalent changes via dev tools and it worked as expected.