### PR TITLE
feat: pass along experimental client capabilities

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -58,6 +58,14 @@ export interface Context<S extends ConfigurationSubject, C extends Settings> {
      * Forces the currently displayed tooltip, if any, to update its contents.
      */
     forceUpdateTooltip(): void
+
+    /**
+     * Experimental capabilities implemented by the client (that are not defined
+     * by the CXP specification). These capabilities are passed verbatim to
+     * extensions in the initialize request's capabilities.experimental
+     * property.
+     */
+    experimentalClientCapabilities?: any
 }
 
 /**

--- a/src/cxp/controller.ts
+++ b/src/cxp/controller.ts
@@ -80,8 +80,7 @@ function environmentFilter<S extends ConfigurationSubject, CC extends Configurat
  */
 export function createController<S extends ConfigurationSubject, C extends Settings>(
     context: Context<S, C>,
-    createMessageTransports: (extension: ConfiguredExtension, options: ClientOptions) => Promise<MessageTransports>,
-    experimentalClientCapabilities?: any
+    createMessageTransports: (extension: ConfiguredExtension, options: ClientOptions) => Promise<MessageTransports>
 ): Controller<ConfiguredExtension, ConfigurationCascade<S, C>> {
     const controller = new Controller<ConfiguredExtension, ConfigurationCascade<S, C>>({
         clientOptions: (key: ClientKey, options: ClientOptions, extension: ConfiguredExtension) => {
@@ -92,7 +91,7 @@ export function createController<S extends ConfigurationSubject, C extends Setti
                 errorHandler,
                 trace: getSavedClientTrace(key),
                 tracer: new BrowserConsoleTracer(extension.id),
-                experimentalClientCapabilities,
+                experimentalClientCapabilities: context.experimentalClientCapabilities,
             }
         },
         environmentFilter,

--- a/src/cxp/controller.ts
+++ b/src/cxp/controller.ts
@@ -80,7 +80,8 @@ function environmentFilter<S extends ConfigurationSubject, CC extends Configurat
  */
 export function createController<S extends ConfigurationSubject, C extends Settings>(
     context: Context<S, C>,
-    createMessageTransports: (extension: ConfiguredExtension, options: ClientOptions) => Promise<MessageTransports>
+    createMessageTransports: (extension: ConfiguredExtension, options: ClientOptions) => Promise<MessageTransports>,
+    experimentalClientCapabilities?: any
 ): Controller<ConfiguredExtension, ConfigurationCascade<S, C>> {
     const controller = new Controller<ConfiguredExtension, ConfigurationCascade<S, C>>({
         clientOptions: (key: ClientKey, options: ClientOptions, extension: ConfiguredExtension) => {
@@ -91,6 +92,7 @@ export function createController<S extends ConfigurationSubject, C extends Setti
                 errorHandler,
                 trace: getSavedClientTrace(key),
                 tracer: new BrowserConsoleTracer(extension.id),
+                experimentalClientCapabilities,
             }
         },
         environmentFilter,


### PR DESCRIPTION
This will be used to pass the `.api/xlang` endpoint to the cx-langserver-http extension.