### PR TITLE
feat: require confirmation to add extensions

### DIFF
--- a/src/extensions/ExtensionConfigureButton.tsx
+++ b/src/extensions/ExtensionConfigureButton.tsx
@@ -64,6 +64,7 @@ export class ExtensionConfiguredSubjectItemForAdd<
 > extends React.PureComponent<
     {
         item: ExtensionConfiguredSubject
+        confirm?: () => boolean
         onUpdate: () => void
         onComplete: () => void
     } & ExtensionsProps<S, C>,
@@ -125,7 +126,9 @@ export class ExtensionConfiguredSubjectItemForAdd<
     }
 
     private onClick: React.MouseEventHandler<HTMLElement> = () => {
-        this.addClicks.next()
+        if (!this.props.confirm || this.props.confirm()) {
+            this.addClicks.next()
+        }
     }
 }
 
@@ -141,6 +144,7 @@ export class ExtensionConfiguredSubjectItemForRemove<
 > extends React.PureComponent<
     {
         item: ExtensionConfiguredSubject
+        confirm?: () => boolean
         onUpdate: () => void
         onComplete: () => void
     } & ExtensionsProps<S, C>,
@@ -199,7 +203,9 @@ export class ExtensionConfiguredSubjectItemForRemove<
     }
 
     private onClick: React.MouseEventHandler<HTMLElement> = () => {
-        this.removeClicks.next()
+        if (!this.props.confirm || this.props.confirm()) {
+            this.removeClicks.next()
+        }
     }
 }
 
@@ -218,7 +224,7 @@ class ExtensionConfigurationSubjectsDropdownItems<
          * feedback about the error (because it is shown in the menu item).
          */
         onComplete: () => void
-    } & Pick<Props<S, C>, 'header' | 'itemComponent' | 'onUpdate'> &
+    } & Pick<Props<S, C>, 'header' | 'itemComponent' | 'confirm' | 'onUpdate'> &
         ExtensionsProps<S, C>
 > {
     public render(): JSX.Element | null {
@@ -336,6 +342,12 @@ interface Props<S extends ConfigurationSubject, C extends Settings>
     /** Whether to show the caret on the dropdown toggle. */
     caret?: boolean
 
+    /**
+     * Called to confirm the primary action. If the callback returns false, the action is not
+     * performed.
+     */
+    confirm?: () => boolean
+
     /** Called when the component performs an update that requires the parent component to refresh data. */
     onUpdate: () => void
 }
@@ -386,6 +398,7 @@ export class ExtensionConfigureButton<S extends ConfigurationSubject, C extends 
                             subject,
                             extension: this.props.extension,
                         }))}
+                        confirm={this.props.confirm}
                         onUpdate={this.props.onUpdate}
                         onComplete={this.onComplete}
                         extensions={this.props.extensions}

--- a/src/extensions/manager/ExtensionCard.tsx
+++ b/src/extensions/manager/ExtensionCard.tsx
@@ -117,6 +117,7 @@ export class ExtensionCard<S extends ConfigurationSubject, C extends Settings> e
                                                     caret={false}
                                                     configurationCascade={this.props.configurationCascade}
                                                     extensions={this.props.extensions}
+                                                    confirm={this.confirmAdd}
                                                 >
                                                     Add
                                                 </ExtensionConfigureButton>
@@ -135,6 +136,21 @@ export class ExtensionCard<S extends ConfigurationSubject, C extends Settings> e
                     </div>
                 </div>
             </div>
+        )
+    }
+
+    private confirmAdd = (): boolean => {
+        // Either `"title" (id)` (if there is a title in the manifest) or else just `id`. It is
+        // important to show the ID because it indicates who the publisher is and allows
+        // disambiguation from other similarly titled extensions.
+        let displayName: string
+        if (this.props.node.manifest && !isErrorLike(this.props.node.manifest) && this.props.node.manifest.title) {
+            displayName = `${JSON.stringify(this.props.node.manifest.title)} (${this.props.node.id})`
+        } else {
+            displayName = this.props.node.id
+        }
+        return confirm(
+            `Add Sourcegraph extension ${displayName}?\n\nIt can:\n- Read repositories and files you view using Sourcegraph\n- Read and change your Sourcegraph settings`
         )
     }
 }


### PR DESCRIPTION
Similar to Chrome, this shows a modal JavaScript confirmation dialog when the user adds an extension using the `Add` button.

The text of the confirmation is:

```
Add Sourcegraph extension "extension title or ID"?

It can:
- Read repositories and files you view using Sourcegraph
- Read and change your Sourcegraph settings
```

The list below "It can" is currently the same for every extension. In the future we can require extensions to request specific permissions.