### PR TITLE
docs: update name to "Sourcegraph extension API" from "CXP"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![sourcegraph: search](https://img.shields.io/badge/sourcegraph-search-brightgreen.svg)](https://sourcegraph.com/github.com/sourcegraph/extensions-client-common)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
-Common TypeScript/React client application code for CXP extension configuration and management, used in:
+Common TypeScript/React client application code for Sourcegraph extension configuration and management, used in:
 
 - Sourcegraph
 - "Sourcegraph for X" products (Chrome extension, Firefox extension, and more soon)

--- a/package-lock.json
+++ b/package-lock.json
@@ -643,6 +643,17 @@
 			"integrity": "sha512-kRdHxdAppxYnN7qAQjNTyuG05pjYHFtEUquZauXVXBeaGB4sye3uSkb8wgi34jeaUHG/gWp2f5hQgCCBMizjjA==",
 			"dev": true
 		},
+		"@sourcegraph/sourcegraph.proposed": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@sourcegraph/sourcegraph.proposed/-/sourcegraph.proposed-12.0.0.tgz",
+			"integrity": "sha512-UdEoYo3OI7mjRR9pqptRcAZ8+VwPWiD3hm2X5wnyWZyaD7xNR8tLkJ/aba+qRv0CJIbaQqlVjoodhEdCsQDkKA==",
+			"requires": {
+				"minimatch": "^3.0.4",
+				"rxjs": "^6.3.1",
+				"uuid": "^3.3.2",
+				"vscode-languageserver-types": "^3.12.0"
+			}
+		},
 		"@sourcegraph/tsconfig": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@sourcegraph/tsconfig/-/tsconfig-3.0.0.tgz",
@@ -1787,17 +1798,6 @@
 			"dev": true,
 			"requires": {
 				"array-find-index": "^1.0.1"
-			}
-		},
-		"cxp": {
-			"version": "11.5.1",
-			"resolved": "https://registry.npmjs.org/cxp/-/cxp-11.5.1.tgz",
-			"integrity": "sha512-Tnph4Jxfa7XfDcH5QW5AvOCVTXf379fe0XVGl48W2tE6OM9bMWUtF5nMMbr7fTOacyVHXbCNR8caLdHD+CfxBw==",
-			"requires": {
-				"minimatch": "^3.0.4",
-				"rxjs": "^6.2.2",
-				"uuid": "^3.3.2",
-				"vscode-languageserver-types": "^3.8.2"
 			}
 		},
 		"dargs": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sourcegraph/extensions-client-common",
   "version": "0.0.0-development",
-  "description": "Common TypeScript/React client application code for CXP extension configuration and management, used in Sourcegraph and \"Sourcegraph for X\" products",
+  "description": "Common TypeScript/React client application code for Sourcegraph extension configuration and management, used in Sourcegraph and \"Sourcegraph for X\" products",
   "author": "Sourcegraph",
   "license": "Apache-2.0",
   "repository": {
@@ -58,8 +58,8 @@
   },
   "sideEffects": false,
   "dependencies": {
+    "@sourcegraph/sourcegraph.proposed": "^12.0.0",
     "bootstrap": "^4.1.3",
-    "cxp": "^11.5.1",
     "lodash-es": "^4.17.10",
     "react": "^16.4.2",
     "react-router": "^4.3.1",

--- a/src/app/CommandList.tsx
+++ b/src/app/CommandList.tsx
@@ -1,11 +1,11 @@
-import { ContributableMenu, Contributions } from 'cxp/module/protocol'
+import { ContributableMenu, Contributions } from '@sourcegraph/sourcegraph.proposed/module/protocol'
 import { isArray, sortBy, uniq } from 'lodash-es'
 import * as React from 'react'
 import { Subscription } from 'rxjs'
 import stringScore from 'string-score'
 import { Key } from 'ts-key-enum'
+import { ControllerProps } from '../client/controller'
 import { ExtensionsProps } from '../context'
-import { CXPControllerProps } from '../cxp/controller'
 import { ConfigurationSubject, Settings } from '../settings'
 import { HighlightedMatches } from '../ui/generic/HighlightedMatches'
 import { PopoverButton } from '../ui/generic/PopoverButton'
@@ -13,7 +13,7 @@ import { ActionItem, ActionItemProps } from './actions/ActionItem'
 import { getContributedActionItems } from './actions/contributions'
 
 interface Props<S extends ConfigurationSubject, C extends Settings>
-    extends CXPControllerProps<S, C>,
+    extends ControllerProps<S, C>,
         ExtensionsProps<S, C> {
     /** The menu whose commands to display. */
     menu: ContributableMenu
@@ -33,7 +33,7 @@ interface State {
     recentActions: string[] | null
 }
 
-/** Displays a list of commands contributed by CXP extensions for a specific menu. */
+/** Displays a list of commands contributed by extensions for a specific menu. */
 export class CommandList<S extends ConfigurationSubject, C extends Settings> extends React.PureComponent<
     Props<S, C>,
     State
@@ -79,7 +79,7 @@ export class CommandList<S extends ConfigurationSubject, C extends Settings> ext
 
     public componentDidMount(): void {
         this.subscriptions.add(
-            this.props.cxpController.registries.contribution.contributions.subscribe(contributions =>
+            this.props.extensionsController.registries.contribution.contributions.subscribe(contributions =>
                 this.setState({ contributions })
             )
         )
@@ -149,7 +149,7 @@ export class CommandList<S extends ConfigurationSubject, C extends Settings> ext
                                 />
                             }
                             onRun={this.onActionRun}
-                            cxpController={this.props.cxpController}
+                            extensionsController={this.props.extensionsController}
                             extensions={this.props.extensions}
                         />
                     ))

--- a/src/app/actions/ActionItem.tsx
+++ b/src/app/actions/ActionItem.tsx
@@ -1,23 +1,23 @@
-import { ActionContribution, ExecuteCommandParams } from 'cxp/module/protocol'
+import { ActionContribution, ExecuteCommandParams } from '@sourcegraph/sourcegraph.proposed/module/protocol'
 import * as React from 'react'
 import { from, Subject, Subscription } from 'rxjs'
 import { catchError, map, mapTo, mergeMap, startWith, tap } from 'rxjs/operators'
+import { ControllerProps } from '../../client/controller'
 import { ExtensionsProps } from '../../context'
-import { CXPControllerProps } from '../../cxp/controller'
 import { asError, ErrorLike } from '../../errors'
 import { ConfigurationSubject, Settings } from '../../settings'
 import { LinkOrButton } from '../../ui/generic/LinkOrButton'
 
 export interface ActionItemProps {
     /**
-     * The action specified in the menu item's {@link module:cxp/module/protocol.MenuItemContribution#action}
+     * The action specified in the menu item's {@link module:@sourcegraph/sourcegraph.proposed.module/protocol.MenuItemContribution#action}
      * property.
      */
     action: ActionContribution
 
     /**
      * The alternative action specified in the menu item's
-     * {@link module:cxp/module/protocol.MenuItemContribution#alt} property.
+     * {@link module:@sourcegraph/sourcegraph.proposed.module/protocol.MenuItemContribution#alt} property.
      */
     altAction?: ActionContribution
 
@@ -38,7 +38,7 @@ export interface ActionItemProps {
 
 interface Props<S extends ConfigurationSubject, C extends Settings>
     extends ActionItemProps,
-        CXPControllerProps<S, C>,
+        ControllerProps<S, C>,
         ExtensionsProps<S, C> {}
 
 const LOADING: 'loading' = 'loading'
@@ -62,7 +62,7 @@ export class ActionItem<S extends ConfigurationSubject, C extends Settings> exte
             this.commandExecutions
                 .pipe(
                     mergeMap(params =>
-                        from(this.props.cxpController.executeCommand(params)).pipe(
+                        from(this.props.extensionsController.executeCommand(params)).pipe(
                             mapTo(null),
                             catchError(error => [asError(error)]),
                             map(c => ({ actionOrError: c })),

--- a/src/app/actions/ActionsContainer.tsx
+++ b/src/app/actions/ActionsContainer.tsx
@@ -32,7 +32,7 @@ export class ActionsContainer<S extends ConfigurationSubject, C extends Settings
 
     public componentDidMount(): void {
         this.subscriptions.add(
-            this.props.cxpController.registries.contribution.contributions.subscribe(contributions =>
+            this.props.extensionsController.registries.contribution.contributions.subscribe(contributions =>
                 this.setState({ contributions })
             )
         )
@@ -62,7 +62,7 @@ export class ActionsContainer<S extends ConfigurationSubject, C extends Settings
                 <ActionItem
                     key={i}
                     {...item}
-                    cxpController={this.props.cxpController}
+                    extensionsController={this.props.extensionsController}
                     extensions={this.props.extensions}
                 />
             ))}

--- a/src/app/actions/ActionsNavItems.tsx
+++ b/src/app/actions/ActionsNavItems.tsx
@@ -19,7 +19,7 @@ export class ActionsNavItems<S extends ConfigurationSubject, C extends Settings>
 
     public componentDidMount(): void {
         this.subscriptions.add(
-            this.props.cxpController.registries.contribution.contributions.subscribe(contributions =>
+            this.props.extensionsController.registries.contribution.contributions.subscribe(contributions =>
                 this.setState({ contributions })
             )
         )
@@ -42,7 +42,7 @@ export class ActionsNavItems<S extends ConfigurationSubject, C extends Settings>
                             key={i}
                             {...item}
                             variant="actionItem"
-                            cxpController={this.props.cxpController}
+                            extensionsController={this.props.extensionsController}
                             extensions={this.props.extensions}
                             className={this.props.actionItemClass}
                         />

--- a/src/app/actions/actions.ts
+++ b/src/app/actions/actions.ts
@@ -1,10 +1,10 @@
-import { ContributableMenu, Contributions } from 'cxp/module/protocol'
+import { ContributableMenu, Contributions } from '@sourcegraph/sourcegraph.proposed/module/protocol'
+import { ControllerProps } from '../../client/controller'
 import { ExtensionsProps } from '../../context'
-import { CXPControllerProps } from '../../cxp/controller'
 import { ConfigurationSubject, Settings } from '../../settings'
 
 export interface ActionsProps<S extends ConfigurationSubject, C extends Settings>
-    extends CXPControllerProps<S, C>,
+    extends ControllerProps<S, C>,
         ExtensionsProps<S, C> {
     menu: ContributableMenu
     actionItemClass?: string

--- a/src/app/actions/contributions.test.ts
+++ b/src/app/actions/contributions.test.ts
@@ -1,5 +1,5 @@
+import { ContributableMenu } from '@sourcegraph/sourcegraph.proposed/module/protocol'
 import assert from 'assert'
-import { ContributableMenu } from 'cxp/module/protocol'
 import { ActionItemProps } from './ActionItem'
 import { getContributedActionItems } from './contributions'
 

--- a/src/app/actions/contributions.ts
+++ b/src/app/actions/contributions.ts
@@ -1,4 +1,4 @@
-import { ContributableMenu, Contributions } from 'cxp/module/protocol'
+import { ContributableMenu, Contributions } from '@sourcegraph/sourcegraph.proposed/module/protocol'
 import { sortBy } from 'lodash-es'
 import { ActionItemProps } from './ActionItem'
 

--- a/src/app/notifications/NotificationItem.tsx
+++ b/src/app/notifications/NotificationItem.tsx
@@ -1,4 +1,4 @@
-import { MessageType } from 'cxp/module/protocol'
+import { MessageType } from '@sourcegraph/sourcegraph.proposed/module/protocol'
 import { upperFirst } from 'lodash-es'
 import * as React from 'react'
 import { isErrorLike } from '../../errors'

--- a/src/app/notifications/Notifications.tsx
+++ b/src/app/notifications/Notifications.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
 import { Subscription } from 'rxjs'
-import { CXPControllerProps } from '../../cxp/controller'
+import { ControllerProps } from '../../client/controller'
 import { ConfigurationSubject, Settings } from '../../settings'
 import { Notification } from './notification'
 import { NotificationItem } from './NotificationItem'
 
-interface Props<S extends ConfigurationSubject, C extends Settings> extends CXPControllerProps<S, C> {}
+interface Props<S extends ConfigurationSubject, C extends Settings> extends ControllerProps<S, C> {}
 
 interface State {
     notifications: Notification[]
@@ -32,7 +32,7 @@ export class Notifications<S extends ConfigurationSubject, C extends Settings> e
 
     public componentDidMount(): void {
         this.subscriptions.add(
-            this.props.cxpController.notifications.subscribe(notification => {
+            this.props.extensionsController.notifications.subscribe(notification => {
                 this.setState(prevState => ({
                     notifications: [notification, ...prevState.notifications.slice(0, Notifications.MAX_RETAIN - 1)],
                 }))

--- a/src/app/notifications/notification.ts
+++ b/src/app/notifications/notification.ts
@@ -1,4 +1,4 @@
-import { MessageType } from 'cxp/module/protocol'
+import { MessageType } from '@sourcegraph/sourcegraph.proposed/module/protocol'
 import { ErrorLike } from '../../errors'
 
 /**

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,5 +1,5 @@
-import { ClientKey } from 'cxp/module/environment/controller'
-import { Trace } from 'cxp/module/jsonrpc2/trace'
+import { ClientKey } from '@sourcegraph/sourcegraph.proposed/module/environment/controller'
+import { Trace } from '@sourcegraph/sourcegraph.proposed/module/jsonrpc2/trace'
 import { isEqual } from 'lodash'
 
 /** Client options persisted in localStorage so that they survive across page reloads. */

--- a/src/client/clientCommands.test.ts
+++ b/src/client/clientCommands.test.ts
@@ -1,5 +1,5 @@
+import { ConfigurationUpdateParams } from '@sourcegraph/sourcegraph.proposed/module/protocol'
 import assert from 'assert'
-import { ConfigurationUpdateParams } from 'cxp/module/protocol'
 import { convertUpdateConfigurationCommandArgs } from './clientCommands'
 
 describe('convertUpdateConfigurationCommandArgs', () => {

--- a/src/client/clientCommands.ts
+++ b/src/client/clientCommands.ts
@@ -1,5 +1,8 @@
-import { Controller } from 'cxp/module/environment/controller'
-import { ActionContributionClientCommandUpdateConfiguration, ConfigurationUpdateParams } from 'cxp/module/protocol'
+import { Controller } from '@sourcegraph/sourcegraph.proposed/module/environment/controller'
+import {
+    ActionContributionClientCommandUpdateConfiguration,
+    ConfigurationUpdateParams,
+} from '@sourcegraph/sourcegraph.proposed/module/protocol'
 import { isArray } from 'lodash-es'
 import { Subscription, throwError, Unsubscribable } from 'rxjs'
 import { switchMap, take } from 'rxjs/operators'
@@ -9,8 +12,9 @@ import { ConfiguredExtension } from '../extensions/extension'
 import { ConfigurationCascade, ConfigurationSubject, Settings } from '../settings'
 
 /**
- * Registers the builtin client commands that are required by CXP. See
- * {@link module:cxp/module/protocol/contribution.ActionContribution#command} for documentation.
+ * Registers the builtin client commands that are required for Sourcegraph extensions. See
+ * {@link module:@sourcegraph/sourcegraph.proposed.module/protocol/contribution.ActionContribution#command} for
+ * documentation.
  */
 export function registerBuiltinClientCommands<S extends ConfigurationSubject, C extends Settings>(
     context: Pick<Context<S, C>, 'configurationCascade' | 'updateExtensionSettings'>,

--- a/src/client/errorHandler.ts
+++ b/src/client/errorHandler.ts
@@ -1,19 +1,19 @@
 import {
     CloseAction,
     ErrorAction,
-    ErrorHandler as CXPErrorHandler,
-    InitializationFailedHandler,
-} from 'cxp/module/client/errorHandler'
-import { Message, ResponseError } from 'cxp/module/jsonrpc2/messages'
-import { InitializeError } from 'cxp/module/protocol'
+    ErrorHandler as _ErrorHandler,
+    InitializationFailedHandler as _InitializationFailedHandler,
+} from '@sourcegraph/sourcegraph.proposed/module/client/errorHandler'
+import { Message, ResponseError } from '@sourcegraph/sourcegraph.proposed/module/jsonrpc2/messages'
+import { InitializeError } from '@sourcegraph/sourcegraph.proposed/module/protocol'
 import { log } from './log'
 
-interface CXPInitializationFailedHandler {
-    initializationFailed: InitializationFailedHandler
+interface InitializationFailedHandler {
+    initializationFailed: _InitializationFailedHandler
 }
 
-/** The CXP client initializion-failed and error handler. */
-export class ErrorHandler implements CXPInitializationFailedHandler, CXPErrorHandler {
+/** The extension client initialization-failed and error handler. */
+export class ErrorHandler implements InitializationFailedHandler, _ErrorHandler {
     /** The number of connection times to record. */
     private static MAX_CONNECTION_TIMESTAMPS = 4
 

--- a/src/client/log.ts
+++ b/src/client/log.ts
@@ -13,7 +13,7 @@ export function log(level: 'info' | 'error', subject: string, message: any, othe
         backgroundColor = 'red'
     }
     f(
-        '%c CXP %s %c',
+        '%c EXT %s %c',
         `font-weight:bold;background-color:${backgroundColor};color:${color}`,
         subject,
         'font-weight:normal;background-color:unset',

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,4 @@
-import { ConfigurationUpdateParams } from 'cxp/module/protocol'
+import { ConfigurationUpdateParams } from '@sourcegraph/sourcegraph.proposed/module/protocol'
 import { Observable } from 'rxjs'
 import { Controller } from './controller'
 import { QueryResult } from './graphql'
@@ -60,10 +60,9 @@ export interface Context<S extends ConfigurationSubject, C extends Settings> {
     forceUpdateTooltip(): void
 
     /**
-     * Experimental capabilities implemented by the client (that are not defined
-     * by the CXP specification). These capabilities are passed verbatim to
-     * extensions in the initialize request's capabilities.experimental
-     * property.
+     * Experimental capabilities implemented by the client (that are not defined by the Sourcegraph extension API
+     * specification). These capabilities are passed verbatim to extensions in the initialize request's
+     * capabilities.experimental property.
      */
     experimentalClientCapabilities?: any
 }

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -4,7 +4,7 @@ import { Context } from './context'
 import { asError, createAggregateError, ErrorLike, isErrorLike } from './errors'
 import { ConfiguredExtension } from './extensions/extension'
 import { gql, graphQLContent, GraphQLDocument } from './graphql'
-import { CXPExtensionManifest } from './schema/extension.schema'
+import { ExtensionManifest } from './schema/extension.schema'
 import * as GQL from './schema/graphqlschema'
 import { ConfigurationCascadeOrError, ConfigurationSubject, Settings } from './settings'
 import { parseJSONCOrError } from './util'
@@ -156,7 +156,7 @@ export class Controller<S extends ConfigurationSubject, C extends Settings> {
                     configuredExtensions.push({
                         id: registryExtension.extensionID,
                         manifest: registryExtension.manifest
-                            ? parseJSONCOrError<CXPExtensionManifest>(registryExtension.manifest.raw)
+                            ? parseJSONCOrError<ExtensionManifest>(registryExtension.manifest.raw)
                             : null,
                         rawManifest:
                             (registryExtension && registryExtension.manifest && registryExtension.manifest.raw) || null,

--- a/src/extensions/extension.ts
+++ b/src/extensions/extension.ts
@@ -1,6 +1,6 @@
-import { Extension } from 'cxp/module/environment/extension'
+import { Extension } from '@sourcegraph/sourcegraph.proposed/module/environment/extension'
 import { ErrorLike, isErrorLike } from '../errors'
-import { CXPExtensionManifest } from '../schema/extension.schema'
+import { ExtensionManifest } from '../schema/extension.schema'
 import * as GQL from '../schema/graphqlschema'
 import { Settings } from '../settings'
 
@@ -18,7 +18,7 @@ export interface ConfiguredExtension<
     >
 > extends Extension {
     /** The parsed extension manifest, null if there is none, or a parse error. */
-    manifest: CXPExtensionManifest | null | ErrorLike
+    manifest: ExtensionManifest | null | ErrorLike
 
     /** The raw extension manifest (JSON), or null if there is none. */
     rawManifest: string | null

--- a/src/schema/extension.schema.json
+++ b/src/schema/extension.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://sourcegraph.com/v1/extension.schema.json#",
-  "title": "CXP extension manifest",
-  "description": "The CXP extension manifest describes the extension and the features it provides.",
+  "title": "Sourcegraph extension manifest",
+  "description": "The Sourcegraph extension manifest describes the extension and the features it provides.",
   "type": "object",
   "additionalProperties": false,
   "required": ["url", "activationEvents"],

--- a/src/schema/extension.schema.ts
+++ b/src/schema/extension.schema.ts
@@ -1,4 +1,4 @@
-import { Contributions } from 'cxp/module/protocol/contribution'
+import { Contributions } from '@sourcegraph/sourcegraph.proposed/module/protocol/contribution'
 
 /**
  * See the extensions.schema.json JSON Schema for canonical documentation on these types.
@@ -10,7 +10,7 @@ import { Contributions } from 'cxp/module/protocol/contribution'
  * manually duplicate it for now.
  */
 
-export interface CXPExtensionManifest {
+export interface ExtensionManifest {
     title?: string
     description?: string
     readme?: string


### PR DESCRIPTION
BREAKING CHANGE: Exported identifiers containing "cxp" have been renamed (e.g., `cxpController` to `extensionsController`).