### PR TITLE
use simplified sourcegraph extension API pkg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2632,14 +2632,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -2654,20 +2652,17 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -2784,8 +2779,7 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -2797,7 +2791,6 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -2812,7 +2805,6 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -2820,14 +2812,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -2846,7 +2836,6 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -2927,8 +2916,7 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -2940,7 +2928,6 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -3062,7 +3049,6 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -10076,9 +10062,9 @@
 			"dev": true
 		},
 		"sourcegraph": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/sourcegraph/-/sourcegraph-13.0.0.tgz",
-			"integrity": "sha512-E75aGMZrIvOSDOn8n4kTdkWAq5mIjKJeRFB3XF/91S+1I5cLODJnewb5RRqCMFCAEkNMNVYa+6lAB5UgKf1Drg==",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/sourcegraph/-/sourcegraph-14.0.0.tgz",
+			"integrity": "sha512-oFJ58S9UsbSzJVjof8HVervI64eec7SktFC+cik3BRYT3cvPWrVbv2spB1qt69/oVzKvk/4DLozNTF02qUT+jQ==",
 			"requires": {
 				"minimatch": "^3.0.4",
 				"rxjs": "^6.3.2",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react-router-dom": "^4.3.1",
     "reactstrap": "^6.4.0",
     "rxjs": "^6.3.2",
-    "sourcegraph": "^13.0.0",
+    "sourcegraph": "^14.0.0",
     "string-score": "^1.0.1",
     "ts-key-enum": "^2.0.0"
   },

--- a/src/app/CommandList.tsx
+++ b/src/app/CommandList.tsx
@@ -1,7 +1,7 @@
-import { ContributableMenu, Contributions } from 'sourcegraph/module/protocol'
 import { isArray, sortBy, uniq } from 'lodash-es'
 import * as React from 'react'
 import { Subscription } from 'rxjs'
+import { ContributableMenu, Contributions } from 'sourcegraph/module/protocol'
 import stringScore from 'string-score'
 import { Key } from 'ts-key-enum'
 import { ControllerProps } from '../client/controller'
@@ -79,9 +79,9 @@ export class CommandList<S extends ConfigurationSubject, C extends Settings> ext
 
     public componentDidMount(): void {
         this.subscriptions.add(
-            this.props.extensionsController.registries.contribution.contributions.subscribe(contributions =>
-                this.setState({ contributions })
-            )
+            this.props.extensionsController.registries.contribution
+                .getContributions()
+                .subscribe(contributions => this.setState({ contributions }))
         )
     }
 

--- a/src/app/ExtensionStatus.tsx
+++ b/src/app/ExtensionStatus.tsx
@@ -1,9 +1,9 @@
-import { Client, ClientState } from 'sourcegraph/module/client/client'
-import { ClientKey } from 'sourcegraph/module/environment/controller'
-import { Trace } from 'sourcegraph/module/jsonrpc2/trace'
 import * as React from 'react'
 import { combineLatest, of, Subject, Subscription } from 'rxjs'
 import { distinctUntilChanged, map, switchMap } from 'rxjs/operators'
+import { Client, ClientState } from 'sourcegraph/module/client/client'
+import { ClientKey } from 'sourcegraph/module/environment/controller'
+import { Trace } from 'sourcegraph/module/jsonrpc2/trace'
 import { updateSavedClientTrace } from '../client/client'
 import { ControllerProps } from '../client/controller'
 import { ConfigurationSubject, Settings } from '../settings'
@@ -90,7 +90,7 @@ export class ExtensionStatus<S extends ConfigurationSubject, C extends Settings>
                                     className="extension-status__client list-group-item d-flex align-items-center justify-content-between py-2"
                                 >
                                     <span className="d-flex align-items-center">
-                                        <span data-tooltip={key.root || 'no root'}>{client.id}</span>
+                                        {client.id}
                                         <span className={`badge badge-${clientStateBadgeClass(state)} ml-1`}>
                                             {ClientState[state]}
                                         </span>

--- a/src/app/actions/ActionItem.tsx
+++ b/src/app/actions/ActionItem.tsx
@@ -1,7 +1,7 @@
-import { ActionContribution, ExecuteCommandParams } from 'sourcegraph/module/protocol'
 import * as React from 'react'
 import { from, Subject, Subscription } from 'rxjs'
 import { catchError, map, mapTo, mergeMap, startWith, tap } from 'rxjs/operators'
+import { ActionContribution, ExecuteCommandParams } from 'sourcegraph/module/protocol'
 import { ControllerProps } from '../../client/controller'
 import { ExtensionsProps } from '../../context'
 import { asError, ErrorLike } from '../../errors'

--- a/src/app/actions/ActionsNavItems.tsx
+++ b/src/app/actions/ActionsNavItems.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react'
-import { Subscription } from 'rxjs'
+import { Subject, Subscription } from 'rxjs'
+import { switchMap } from 'rxjs/operators'
+import { Component } from 'sourcegraph/module/environment/environment'
 import { ConfigurationSubject, Settings } from '../../settings'
 import { ActionItem } from './ActionItem'
 import { ActionsProps, ActionsState } from './actions'
 import { getContributedActionItems } from './contributions'
 
 /**
- * Renders the actions a fragment of <li class="nav-item"> elements, for use in a Bootstrap <ul class="nav"> or <ul
- * class="navbar-nav">.
+ * Renders the actions as a fragment of <li class="nav-item"> elements, for use in a Bootstrap <ul
+ * class="nav"> or <ul class="navbar-nav">.
  */
 export class ActionsNavItems<S extends ConfigurationSubject, C extends Settings> extends React.PureComponent<
     ActionsProps<S, C>,
@@ -15,14 +17,24 @@ export class ActionsNavItems<S extends ConfigurationSubject, C extends Settings>
 > {
     public state: ActionsState = {}
 
+    private scopeChanges = new Subject<Component | undefined>()
     private subscriptions = new Subscription()
 
     public componentDidMount(): void {
         this.subscriptions.add(
-            this.props.extensionsController.registries.contribution.contributions.subscribe(contributions =>
-                this.setState({ contributions })
-            )
+            this.scopeChanges
+                .pipe(
+                    switchMap(scope => this.props.extensionsController.registries.contribution.getContributions(scope))
+                )
+                .subscribe(contributions => this.setState({ contributions }))
         )
+        this.scopeChanges.next(this.props.scope)
+    }
+
+    public componentDidUpdate(prevProps: ActionsProps<S, C>): void {
+        if (prevProps.scope !== this.props.scope) {
+            this.scopeChanges.next(this.props.scope)
+        }
     }
 
     public componentWillUnmount(): void {

--- a/src/app/actions/actions.ts
+++ b/src/app/actions/actions.ts
@@ -1,3 +1,4 @@
+import { Component } from 'sourcegraph/module/environment/environment'
 import { ContributableMenu, Contributions } from 'sourcegraph/module/protocol'
 import { ControllerProps } from '../../client/controller'
 import { ExtensionsProps } from '../../context'
@@ -7,6 +8,7 @@ export interface ActionsProps<S extends ConfigurationSubject, C extends Settings
     extends ControllerProps<S, C>,
         ExtensionsProps<S, C> {
     menu: ContributableMenu
+    scope?: Component
     actionItemClass?: string
     listClass?: string
 }

--- a/src/app/notifications/NotificationItem.tsx
+++ b/src/app/notifications/NotificationItem.tsx
@@ -1,6 +1,6 @@
-import { MessageType } from 'sourcegraph/module/protocol'
 import { upperFirst } from 'lodash-es'
 import * as React from 'react'
+import { MessageType } from 'sourcegraph/module/protocol'
 import { isErrorLike } from '../../errors'
 import { Notification } from './notification'
 

--- a/src/client/controller.ts
+++ b/src/client/controller.ts
@@ -119,7 +119,6 @@ export function createController<S extends ConfigurationSubject, C extends Setti
             const errorHandler = new ErrorHandler(extension.id)
             return {
                 createMessageTransports: () => createMessageTransports(extension, options),
-                initializationFailedHandler: err => errorHandler.initializationFailed(err),
                 errorHandler,
                 trace: getSavedClientTrace(key),
                 tracer: new BrowserConsoleTracer(extension.id),


### PR DESCRIPTION
Updates this package to work with simplifications in the `sourcegraph` npm package (see https://github.com/sourcegraph/sourcegraph-extension-api/pull/50).