### PR TITLE
feat: add a messaging API between page and client

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -5,6 +5,15 @@ import { QueryResult } from './graphql'
 import * as GQL from './schema/graphqlschema'
 import { ConfigurationCascadeOrError, ConfigurationSubject, ID, Settings } from './settings'
 
+export type UpdateExtensionSettingsArgs =
+    | { edit?: ConfigurationUpdateParams }
+    | {
+          extensionID: string
+          // TODO: unclean api, allows 4 states (2 bools), but only 3 are valid (none/disabled/enabled)
+          enabled?: boolean
+          remove?: boolean
+      }
+
 /**
  * Description of the context in which extensions-client-common is running, and platform-specific hooks.
  */
@@ -15,20 +24,7 @@ export interface Context<S extends ConfigurationSubject, C extends Settings> {
      */
     readonly configurationCascade: Subscribable<ConfigurationCascadeOrError<S, C>>
 
-    /**
-     * Updates the extension settings for extensionID and for the given subject.
-     */
-    updateExtensionSettings(
-        subject: ID,
-        args:
-            | { edit?: ConfigurationUpdateParams }
-            | {
-                  extensionID: string
-                  // TODO: unclean api, allows 4 states (2 bools), but only 3 are valid (none/disabled/enabled)
-                  enabled?: boolean
-                  remove?: boolean
-              }
-    ): Subscribable<void>
+    updateExtensionSettings(subject: ID, args: UpdateExtensionSettingsArgs): Subscribable<void>
 
     /**
      * Sends a request to the Sourcegraph GraphQL API and returns the response.

--- a/src/messaging.ts
+++ b/src/messaging.ts
@@ -1,0 +1,144 @@
+import { fromEvent, Observable } from 'rxjs'
+import { filter, map, take } from 'rxjs/operators'
+import { UpdateExtensionSettingsArgs } from './context'
+
+/**
+ * One end of the client-page connection. The browser extension is a client, and
+ * the web app is a page.
+ */
+export type Source = 'Client' | 'Page'
+
+/** Useful for building tagged union types. */
+interface Tagged<T> {
+    type: T
+}
+
+/**
+ * Enumeration of all the types of messages that could be sent between the page
+ * and client.
+ */
+type MessageType = 'Ping' | 'EditSettings' | 'GetSettings' | 'Settings'
+
+/**
+ * The first message sent between the page and client, and used to detect
+ * presence of each other.
+ */
+export interface Ping extends Tagged<MessageType> {
+    type: 'Ping'
+}
+
+/**
+ * Intent to change a settings value. This is sent from the page to the client.
+ */
+export interface EditSettings extends Tagged<MessageType> {
+    type: 'EditSettings'
+    edit: UpdateExtensionSettingsArgs
+}
+
+/**
+ * A request for the client to send the latest settings back. This is sent from
+ * the page to the client.
+ */
+export interface GetSettings extends Tagged<MessageType> {
+    type: 'GetSettings'
+}
+
+/**
+ * A notification that the client settings have been updated. This is sent from
+ * the client to the page.
+ */
+export interface Settings extends Tagged<MessageType> {
+    type: 'Settings'
+    settings: string
+}
+
+/** A message that is passed between the client and page. */
+type Message = Ping | EditSettings | GetSettings | Settings
+
+/** A connection to the client. */
+export interface ClientConnection {
+    /** Listens for the latest client settings. */
+    onSettings: (callback: (settings: string) => void) => void
+
+    /** Tells the client to update a setting. */
+    editSettings: (edit: UpdateExtensionSettingsArgs) => void
+
+    /** Asks the client for its settings. */
+    getSettings: () => void
+}
+
+/** A connection to the page. */
+export interface PageConnection {
+    /** Listens for requests to edit settings. */
+    onEditSettings: (callback: (edit: UpdateExtensionSettingsArgs) => void) => void
+
+    /** Listens for requests for the latest settings. */
+    onGetSettings: (callback: () => void) => void
+
+    /** Notifies the page that the settings have been updated. */
+    sendSettings: (settings: string) => void
+}
+
+/** A low-level connection between the client and page. */
+interface Connection {
+    onMessage: (callback: (message: Message) => void) => void
+    sendMessage: (message: Message) => void
+}
+
+/**
+ * Attempts to connect to the client/page and only resolves when the other end
+ * pings back.
+ *
+ * Both the page and client send out an initial Ping, then another Ping for any
+ * Ping that it receives from the other end. That way, both the page and client
+ * will receive a ping no matter which one executes first. The receipt of a Ping
+ * signals that the other end is present and ready to receive other messages.
+ */
+function connectTo(other: Source): Promise<Connection> {
+    const me = { Client: 'Page', Page: 'Client' }[other]
+
+    return new Promise(resolve => {
+        const incomingMessages: Observable<Message> = fromEvent<MessageEvent>(window, 'message').pipe(
+            map<MessageEvent, Message & { source: Source } | undefined>(event => event.data),
+            filter((message): message is Message & { source: Source } => !!message && message.source === other)
+        )
+
+        const connection: Connection = {
+            onMessage: callback => {
+                incomingMessages.subscribe(callback)
+            },
+            sendMessage: (message: Message): void => {
+                window.postMessage({ source: me, ...message }, '*')
+            },
+        }
+
+        const ping = () => connection.sendMessage({ type: 'Ping' })
+
+        incomingMessages.pipe(take(1)).subscribe(() => {
+            ping()
+            resolve(connection)
+        })
+        ping()
+    })
+}
+
+/** Resolves when the client is ready to exchange messages. */
+export function connectToClient(): Promise<ClientConnection> {
+    return connectTo('Client').then(connection => ({
+        onSettings: (callback: (settings: string) => void) =>
+            connection.onMessage(message => (message.type === 'Settings' ? callback(message.settings) : undefined)),
+        getSettings: () => connection.sendMessage({ type: 'GetSettings' }),
+        editSettings: (edit: UpdateExtensionSettingsArgs) => connection.sendMessage({ type: 'EditSettings', edit }),
+    }))
+}
+
+/** Resolves when the page is ready to exchange messages. */
+export function connectToPage(): Promise<PageConnection> {
+    return connectTo('Page').then(connection => ({
+        onEditSettings: (callback: (edit: UpdateExtensionSettingsArgs) => void) =>
+            connection.onMessage(message => (message.type === 'EditSettings' ? callback(message.edit) : undefined)),
+        onGetSettings: (callback: () => void) =>
+            connection.onMessage(message => (message.type === 'GetSettings' ? callback() : undefined)),
+        sendSettings: (settings: string) => connection.sendMessage({ type: 'Settings', settings }),
+    }))
+}

--- a/src/messaging.ts
+++ b/src/messaging.ts
@@ -8,29 +8,18 @@ import { UpdateExtensionSettingsArgs } from './context'
  */
 export type Source = 'Client' | 'Page'
 
-/** Useful for building tagged union types. */
-interface Tagged<T> {
-    type: T
-}
-
-/**
- * Enumeration of all the types of messages that could be sent between the page
- * and client.
- */
-type MessageType = 'Ping' | 'EditSettings' | 'GetSettings' | 'Settings'
-
 /**
  * The first message sent between the page and client, and used to detect
  * presence of each other.
  */
-export interface Ping extends Tagged<MessageType> {
+export interface Ping {
     type: 'Ping'
 }
 
 /**
  * Intent to change a settings value. This is sent from the page to the client.
  */
-export interface EditSettings extends Tagged<MessageType> {
+export interface EditSettings {
     type: 'EditSettings'
     edit: UpdateExtensionSettingsArgs
 }
@@ -39,7 +28,7 @@ export interface EditSettings extends Tagged<MessageType> {
  * A request for the client to send the latest settings back. This is sent from
  * the page to the client.
  */
-export interface GetSettings extends Tagged<MessageType> {
+export interface GetSettings {
     type: 'GetSettings'
 }
 
@@ -47,7 +36,7 @@ export interface GetSettings extends Tagged<MessageType> {
  * A notification that the client settings have been updated. This is sent from
  * the client to the page.
  */
-export interface Settings extends Tagged<MessageType> {
+export interface Settings {
     type: 'Settings'
     settings: string
 }

--- a/src/messaging.ts
+++ b/src/messaging.ts
@@ -88,7 +88,7 @@ function connectTo(other: Source): Promise<Connection> {
 
     return new Promise(resolve => {
         const incomingMessages: Observable<Message> = fromEvent<MessageEvent>(window, 'message').pipe(
-            map<MessageEvent, Message & { source: Source } | undefined>(event => event.data),
+            map<MessageEvent, Message & { source?: Source } | undefined>(event => event.data),
             filter((message): message is Message & { source: Source } => !!message && message.source === other)
         )
 


### PR DESCRIPTION
This adds a messaging API between the page and client so that anonymous users can use the same `/extensions` page as authenticated users would on a Sourcegraph instance to add/remove Sourcegraph extensions.

- Makes a type out of the arguments to `updateExtensionSettings` for reuse
- Defines types of messages that can be sent between the page and client
- Defines a connection interface for each (client/page)

Usage:

```typescript
// from the browser extension
connectAsClient().then(connection => {
  connection.onGetSettings(() => Promise.resolve('{}'))
})

// from the page
connectToClient().then(connection => {
  connection.onSettings(console.log)
  connection.getSettings().then(console.log)
})
```

Known limitations:

- You can't  unsubscribe from `onSettings` et al., but I haven't encountered any use case for this yet.
- There is no request/response functionality such as JSON-RPC built-in, but there was only 1 instance where this would have been helpful (updating a client setting) and this can be nearly emulated with a `Subject` and `pipe(take(1)).subscribe()`, which is what I opted for in the web app.