### PR TITLE
refactor: export Subscribables instead of Observables

### DIFF
--- a/src/client/clientCommands.ts
+++ b/src/client/clientCommands.ts
@@ -1,5 +1,5 @@
 import { isArray } from 'lodash-es'
-import { Subscription, throwError, Unsubscribable } from 'rxjs'
+import { from, Subscription, throwError, Unsubscribable } from 'rxjs'
 import { switchMap, take } from 'rxjs/operators'
 import { Controller } from 'sourcegraph/module/environment/controller'
 import {
@@ -60,7 +60,7 @@ export function updateConfiguration<S extends ConfigurationSubject, C extends Se
 ): Promise<void> {
     // TODO(sqs): Allow extensions to specify which subject's configuration to update
     // (instead of always updating the highest-precedence subject's configuration).
-    return context.configurationCascade
+    return from(context.configurationCascade)
         .pipe(
             take(1),
             switchMap(x => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,4 @@
-import { Observable } from 'rxjs'
+import { Subscribable } from 'rxjs'
 import { ConfigurationUpdateParams } from 'sourcegraph/module/protocol'
 import { Controller } from './controller'
 import { QueryResult } from './graphql'
@@ -13,7 +13,7 @@ export interface Context<S extends ConfigurationSubject, C extends Settings> {
      * An observable that emits whenever the configuration cascade changes (including when any individual subject's
      * settings change).
      */
-    readonly configurationCascade: Observable<ConfigurationCascadeOrError<S, C>>
+    readonly configurationCascade: Subscribable<ConfigurationCascadeOrError<S, C>>
 
     /**
      * Updates the extension settings for extensionID and for the given subject.
@@ -28,7 +28,7 @@ export interface Context<S extends ConfigurationSubject, C extends Settings> {
                   enabled?: boolean
                   remove?: boolean
               }
-    ): Observable<void>
+    ): Subscribable<void>
 
     /**
      * Sends a request to the Sourcegraph GraphQL API and returns the response.
@@ -40,7 +40,7 @@ export interface Context<S extends ConfigurationSubject, C extends Settings> {
     queryGraphQL(
         request: string,
         variables?: { [name: string]: any }
-    ): Observable<QueryResult<Pick<GQL.IQuery, 'extensionRegistry'>>>
+    ): Subscribable<QueryResult<Pick<GQL.IQuery, 'extensionRegistry'>>>
 
     /**
      * React components for icons. They are expected to size themselves appropriately with the surrounding DOM flow

--- a/src/extensions/ExtensionConfigureButton.tsx
+++ b/src/extensions/ExtensionConfigureButton.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Link } from 'react-router-dom'
 import { ButtonDropdown, DropdownMenu, DropdownToggle } from 'reactstrap'
 import DropdownItem from 'reactstrap/lib/DropdownItem'
-import { Subject, Subscription } from 'rxjs'
+import { from, Subject, Subscription } from 'rxjs'
 import { catchError, map, mapTo, startWith, switchMap, tap } from 'rxjs/operators'
 import { ExtensionsProps } from '../context'
 import { asError, ErrorLike, isErrorLike } from '../errors'
@@ -80,19 +80,19 @@ export class ExtensionConfiguredSubjectItemForAdd<
             this.addClicks
                 .pipe(
                     switchMap(() =>
-                        this.props.extensions.context
-                            .updateExtensionSettings(this.props.item.subject.subject.id, {
+                        from(
+                            this.props.extensions.context.updateExtensionSettings(this.props.item.subject.subject.id, {
                                 extensionID: this.props.item.extension.id,
                                 enabled: true,
                             })
-                            .pipe(
-                                mapTo(null),
-                                tap(() => this.props.onComplete()),
-                                catchError(error => [asError(error) as ErrorLike]),
-                                map(c => ({ addOrError: c } as ExtensionConfiguredSubjectItemForAddState)),
-                                tap(() => this.props.onUpdate()),
-                                startWith<ExtensionConfiguredSubjectItemForAddState>({ addOrError: LOADING })
-                            )
+                        ).pipe(
+                            mapTo(null),
+                            tap(() => this.props.onComplete()),
+                            catchError(error => [asError(error) as ErrorLike]),
+                            map(c => ({ addOrError: c } as ExtensionConfiguredSubjectItemForAddState)),
+                            tap(() => this.props.onUpdate()),
+                            startWith<ExtensionConfiguredSubjectItemForAddState>({ addOrError: LOADING })
+                        )
                     )
                 )
                 .subscribe(stateUpdate => this.setState(stateUpdate), error => console.error(error))
@@ -160,19 +160,19 @@ export class ExtensionConfiguredSubjectItemForRemove<
             this.removeClicks
                 .pipe(
                     switchMap(() =>
-                        this.props.extensions.context
-                            .updateExtensionSettings(this.props.item.subject.subject.id, {
+                        from(
+                            this.props.extensions.context.updateExtensionSettings(this.props.item.subject.subject.id, {
                                 extensionID: this.props.item.extension.id,
                                 remove: true,
                             })
-                            .pipe(
-                                mapTo(null),
-                                tap(() => this.props.onComplete()),
-                                catchError(error => [asError(error) as ErrorLike]),
-                                map(c => ({ removeOrError: c } as ExtensionConfiguredSubjectItemForRemoveState)),
-                                tap(() => this.props.onUpdate()),
-                                startWith<ExtensionConfiguredSubjectItemForRemoveState>({ removeOrError: LOADING })
-                            )
+                        ).pipe(
+                            mapTo(null),
+                            tap(() => this.props.onComplete()),
+                            catchError(error => [asError(error) as ErrorLike]),
+                            map(c => ({ removeOrError: c } as ExtensionConfiguredSubjectItemForRemoveState)),
+                            tap(() => this.props.onUpdate()),
+                            startWith<ExtensionConfiguredSubjectItemForRemoveState>({ removeOrError: LOADING })
+                        )
                     )
                 )
                 .subscribe(stateUpdate => this.setState(stateUpdate), error => console.error(error))

--- a/src/extensions/ExtensionEnablementToggle.tsx
+++ b/src/extensions/ExtensionEnablementToggle.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { combineLatest, Subject, Subscription } from 'rxjs'
+import { combineLatest, Subject, Subscription, from } from 'rxjs'
 import { catchError, distinctUntilChanged, map, mapTo, startWith, switchMap, tap } from 'rxjs/operators'
 import { ExtensionsProps } from '../context'
 import { asError, ErrorLike, isErrorLike } from '../errors'
@@ -64,22 +64,22 @@ export class ExtensionEnablementToggle<S extends ConfigurationSubject, C extends
             this.toggles
                 .pipe(
                     switchMap(enabled =>
-                        this.props.extensions.context
-                            .updateExtensionSettings(this.props.subject.id, {
+                        from(
+                            this.props.extensions.context.updateExtensionSettings(this.props.subject.id, {
                                 extensionID: this.props.extension.id,
                                 enabled,
                             })
-                            .pipe(
-                                mapTo(true),
-                                catchError(error => [asError(error) as ErrorLike]),
-                                map(c => ({ toggleOrError: c } as State)),
-                                tap(() => {
-                                    if (this.props.onChange) {
-                                        this.props.onChange(enabled)
-                                    }
-                                }),
-                                startWith<State>({ toggleOrError: LOADING })
-                            )
+                        ).pipe(
+                            mapTo(true),
+                            catchError(error => [asError(error) as ErrorLike]),
+                            map(c => ({ toggleOrError: c } as State)),
+                            tap(() => {
+                                if (this.props.onChange) {
+                                    this.props.onChange(enabled)
+                                }
+                            }),
+                            startWith<State>({ toggleOrError: LOADING })
+                        )
                     )
                 )
                 .subscribe(stateUpdate => this.setState(stateUpdate), error => console.error(error))

--- a/src/extensions/manager/ExtensionsList.tsx
+++ b/src/extensions/manager/ExtensionsList.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
-import { combineLatest, concat, Observable, of, Subject, Subscription } from 'rxjs'
+import { combineLatest, concat, from, Observable, of, Subject, Subscription } from 'rxjs'
 import {
     catchError,
     debounceTime,
@@ -254,8 +254,8 @@ export class ExtensionsList<S extends ConfigurationSubject, C extends Settings> 
             take(1),
 
             switchMap(viewerExtensions =>
-                this.props.extensions.context
-                    .queryGraphQL(
+                from(
+                    this.props.extensions.context.queryGraphQL(
                         gql`
                             query RegistryExtensions($query: String, $prioritizeExtensionIDs: [String!]!) {
                                 extensionRegistry {
@@ -274,17 +274,17 @@ export class ExtensionsList<S extends ConfigurationSubject, C extends Settings> 
                             prioritizeExtensionIDs: viewerExtensions.map(({ id }) => id),
                         } as GQL.IExtensionsOnExtensionRegistryArguments
                     )
-                    .pipe(
-                        map(({ data, errors }) => {
-                            if (!data || !data.extensionRegistry || !data.extensionRegistry.extensions || errors) {
-                                throw createAggregateError(errors)
-                            }
-                            return {
-                                registryExtensions: data.extensionRegistry.extensions.nodes,
-                                error: data.extensionRegistry.extensions.error,
-                            }
-                        })
-                    )
+                ).pipe(
+                    map(({ data, errors }) => {
+                        if (!data || !data.extensionRegistry || !data.extensionRegistry.extensions || errors) {
+                            throw createAggregateError(errors)
+                        }
+                        return {
+                            registryExtensions: data.extensionRegistry.extensions.nodes,
+                            error: data.extensionRegistry.extensions.error,
+                        }
+                    })
+                )
             ),
             switchMap(({ registryExtensions, error }) =>
                 this.props.extensions


### PR DESCRIPTION
Type errors are preventing linking from working in browser-extensions (I believe due to https://github.com/Microsoft/TypeScript/issues/6496). This exports `Subscribable`s, which are interfaces and don't appear to cause type errors, instead of `Observables`, which are classes and do appear to cause type errors.

This pattern is from https://github.com/sourcegraph/codeintellify/pull/49