### PR TITLE
fix: remove unused viewerCanAdminister

### DIFF
--- a/src/extensions/manager/ExtensionsList.tsx
+++ b/src/extensions/manager/ExtensionsList.tsx
@@ -52,7 +52,6 @@ export const registryExtensionFragment = gql`
         remoteURL
         registryName
         isLocal
-        viewerCanAdminister
     }
 `
 


### PR DESCRIPTION
Previously, `viewerCanAdminister` would return errors when the current user was neither an admin nor the publisher of the extension.

The value doesn't appear to be used anywhere, but it had the side effect of preventing non-admin users from viewing the registry.

This fixes' https://github.com/sourcegraph/sourcegraph/issues/13366 and https://github.com/sourcegraph/sourcegraph/issues/13367