### PR TITLE
feat: edit settings for the highest precedence subject

### DIFF
--- a/src/extensions/ExtensionConfigureButtonDropdown.tsx
+++ b/src/extensions/ExtensionConfigureButtonDropdown.tsx
@@ -162,10 +162,7 @@ export class ExtensionConfigureButtonDropdown<
                     {this.props.children}
                 </DropdownToggle>
                 <DropdownMenu>
-                    <DropdownItem header={true}>
-                        User settings ({subjectLabel(this.props.subject.subject)}
-                        ):
-                    </DropdownItem>
+                    <DropdownItem header={true}>{subjectLabel(this.props.subject.subject)} settings:</DropdownItem>
                     <ExtensionConfigureDropdownItem
                         extension={this.props.extension}
                         subject={this.props.subject}

--- a/src/extensions/ExtensionPrimaryActionButton.tsx
+++ b/src/extensions/ExtensionPrimaryActionButton.tsx
@@ -43,11 +43,13 @@ export class ExtensionPrimaryActionButton<
             return null
         }
 
-        // Only operate on the current user's extension configuration, for simplicity.
-        const userSubject = this.props.configurationCascade.subjects.find(
-            ({ subject }) => subject.__typename === 'User'
-        )
-        if (!userSubject || !userSubject.subject.viewerCanAdminister) {
+        // Only operate on the highest precedence settings, for simplicity.
+        const subjects = this.props.configurationCascade.subjects
+        if (subjects.length === 0) {
+            return null
+        }
+        const highestPrecedenceSubject = subjects[subjects.length - 1]
+        if (!highestPrecedenceSubject || !highestPrecedenceSubject.subject.viewerCanAdminister) {
             return null
         }
 
@@ -57,7 +59,7 @@ export class ExtensionPrimaryActionButton<
             return (
                 <ExtensionAddButton
                     extension={this.props.extension}
-                    subject={userSubject}
+                    subject={highestPrecedenceSubject}
                     confirm={this.confirm}
                     onUpdate={this.props.onUpdate}
                     className={`btn ${this.props.className || ''} ${this.props.addClassName || ''}`}
@@ -71,7 +73,7 @@ export class ExtensionPrimaryActionButton<
             <div className="btn-group" role="group" aria-label="Extension configuration actions">
                 <ExtensionConfigureButtonDropdown
                     extension={this.props.extension}
-                    subject={userSubject}
+                    subject={highestPrecedenceSubject}
                     configurationCascade={this.props.configurationCascade}
                     confirm={this.confirm}
                     onUpdate={this.props.onUpdate}


### PR DESCRIPTION
Previously, the add/remove/enable/disable buttons only showed up if you were signed in.

This changes the logic to pick the highest precedence subject (which is often User settings), which enables the browser extension to work again.

![image](https://user-images.githubusercontent.com/1387653/46182511-27da7c80-c281-11e8-84af-06995ba6b3cc.png)

Continuation of https://github.com/sourcegraph/extensions-client-common/commit/7f1d38cb725285cd940bba8582c99da80bde8940

