### PR TITLE
feat: mark safe GraphQL requests

### DIFF
--- a/src/client/clientCommands.ts
+++ b/src/client/clientCommands.ts
@@ -56,7 +56,12 @@ export function registerBuiltinClientCommands<S extends ConfigurationSubject, C 
         controller.registries.commands.registerCommand({
             command: 'queryGraphQL',
             run: (query: string, variables: { [name: string]: any }): Promise<any> =>
-                from(context.queryGraphQL(query, variables)).toPromise(),
+                // 🚨 SECURITY: The request might contain private info (such as
+                // repository names), so the `mightContainPrivateInfo` parameter
+                // is set to `true`. It is up to the client (e.g. browser
+                // extension) to check that parameter and prevent the request
+                // from being sent to Sourcegraph.com.
+                from(context.queryGraphQL(query, variables, true)).toPromise(),
         })
     )
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -31,11 +31,14 @@ export interface Context<S extends ConfigurationSubject, C extends Settings> {
      *
      * @param request The GraphQL request (query or mutation)
      * @param variables An object whose properties are GraphQL query name-value variable pairs
+     * @param mightContainPrivateInfo 🚨 SECURITY: Whether or not sending the GraphQL request to Sourcegraph.com
+     * could leak private information such as repository names.
      * @return Observable that emits the result or an error if the HTTP request failed
      */
     queryGraphQL(
         request: string,
-        variables?: { [name: string]: any }
+        variables?: { [name: string]: any },
+        mightContainPrivateInfo?: boolean
     ): Subscribable<QueryResult<Pick<GQL.IQuery, 'extensionRegistry'>>>
 
     /**

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -55,7 +55,8 @@ export class Controller<S extends ConfigurationSubject, C extends Settings> {
                     }
                     ${registryExtensionFragment}
                 `[graphQLContent],
-                { extensionID }
+                { extensionID },
+                false
             )
         )
             .pipe(
@@ -104,7 +105,8 @@ export class Controller<S extends ConfigurationSubject, C extends Settings> {
                 {
                     first: extensionIDs.length,
                     prioritizeExtensionIDs: extensionIDs,
-                }
+                },
+                false
             )
         ).pipe(
             map(({ data, errors }) => {

--- a/src/extensions/manager/ExtensionsList.tsx
+++ b/src/extensions/manager/ExtensionsList.tsx
@@ -271,7 +271,8 @@ export class ExtensionsList<S extends ConfigurationSubject, C extends Settings> 
                         {
                             ...args,
                             prioritizeExtensionIDs: viewerExtensions.map(({ id }) => id),
-                        } as GQL.IExtensionsOnExtensionRegistryArguments
+                        } as GQL.IExtensionsOnExtensionRegistryArguments,
+                        false
                     )
                 ).pipe(
                     map(({ data, errors }) => {


### PR DESCRIPTION
I'm planning to support running extensions (e.g. Codecov) on private code even when the repository does not exist on the Sourcegraph instance. Doing so will resolve this issue: https://github.com/sourcegraph/browser-extensions/issues/234#issuecomment-430429015

The browser extension currently blocks all GraphQL requests sent from a private repository to Sourcegraph.com, but it needs to allow e-c-c to send certain GraphQL requests that fetch configuration and extension metadata (e.g. the manifest) in order to run extensions on private repositories. At the same time, it still needs to prevent GraphQL requests that might contain private information (such as repo names) up to Sourcegraph.com.

This PR marks known-safe GraphQL requests so that the browser extension can allow these requests to be sent to the Sourcegraph instance.