### PR TITLE
feat: openPanel command to open a panel view from an extension

### DIFF
--- a/src/app/CommandList.tsx
+++ b/src/app/CommandList.tsx
@@ -1,4 +1,5 @@
 import { ShortcutProps } from '@slimsag/react-shortcuts'
+import H from 'history'
 import { isArray, sortBy, uniq } from 'lodash-es'
 import * as React from 'react'
 import { Subscription } from 'rxjs'
@@ -21,6 +22,8 @@ interface Props<S extends ConfigurationSubject, C extends Settings>
 
     /** Called when the user has selected an item in the list. */
     onSelect?: () => void
+
+    location: H.Location
 }
 
 interface State {
@@ -152,6 +155,7 @@ export class CommandList<S extends ConfigurationSubject, C extends Settings> ext
                             onRun={this.onActionRun}
                             extensionsController={this.props.extensionsController}
                             extensions={this.props.extensions}
+                            location={this.props.location}
                         />
                     ))
                 ) : (

--- a/src/app/actions/ActionsContainer.tsx
+++ b/src/app/actions/ActionsContainer.tsx
@@ -76,6 +76,7 @@ export class ActionsContainer<S extends ConfigurationSubject, C extends Settings
                     {...item}
                     extensionsController={this.props.extensionsController}
                     extensions={this.props.extensions}
+                    location={this.props.location}
                 />
             ))}
         </>

--- a/src/app/actions/ActionsNavItems.tsx
+++ b/src/app/actions/ActionsNavItems.tsx
@@ -57,6 +57,7 @@ export class ActionsNavItems<S extends ConfigurationSubject, C extends Settings>
                             extensionsController={this.props.extensionsController}
                             extensions={this.props.extensions}
                             className={this.props.actionItemClass}
+                            location={this.props.location}
                         />
                     </li>
                 ))}

--- a/src/app/actions/actions.ts
+++ b/src/app/actions/actions.ts
@@ -1,3 +1,4 @@
+import H from 'history'
 import { TextDocumentItem } from 'sourcegraph/module/client/types/textDocument'
 import { ContributableMenu, Contributions } from 'sourcegraph/module/protocol'
 import { ControllerProps } from '../../client/controller'
@@ -11,6 +12,7 @@ export interface ActionsProps<S extends ConfigurationSubject, C extends Settings
     scope?: TextDocumentItem
     actionItemClass?: string
     listClass?: string
+    location: H.Location
 }
 
 export interface ActionsState {

--- a/src/client/clientCommands.ts
+++ b/src/client/clientCommands.ts
@@ -40,6 +40,18 @@ export function registerBuiltinClientCommands<S extends ConfigurationSubject, C 
 
     subscription.add(
         controller.registries.commands.registerCommand({
+            command: 'openPanel',
+            run: (viewID: string) => {
+                // As above for `open`, the `openPanel` client command is usually implemented by an HTML <a>
+                // element.
+                window.open(urlForOpenPanel(viewID, window.location.hash))
+                return Promise.resolve()
+            },
+        })
+    )
+
+    subscription.add(
+        controller.registries.commands.registerCommand({
             command: 'updateConfiguration',
             run: (...anyArgs: any[]): Promise<void> => {
                 const args = anyArgs as ActionContributionClientCommandUpdateConfiguration['commandArguments']
@@ -77,6 +89,26 @@ export function registerBuiltinClientCommands<S extends ConfigurationSubject, C 
     )
 
     return subscription
+}
+
+/**
+ * Constructs the URL that will result in the panel being opened to the specified view. Other parameters in the URL
+ * hash are preserved.
+ *
+ * @param viewID The ID of the view to open in the panel.
+ * @param urlHash The current URL hash (beginning with '#' if non-empty).
+ */
+export function urlForOpenPanel(viewID: string, urlHash: string): string {
+    // Preserve the existing URL fragment, if any.
+    const params = new URLSearchParams(urlHash.slice('#'.length))
+    params.set('tab', viewID)
+    // In the URL fragment, the 'L1:2-3:4' is treated as a parameter with no value. Undo the escaping of ':'
+    // and the addition of the '=' for the empty value, for aesthetic reasons.
+    const paramsString = params
+        .toString()
+        .replace(/%3A/g, ':')
+        .replace(/=&/g, '&')
+    return `#${paramsString}`
 }
 
 /**


### PR DESCRIPTION
See https://github.com/sqs/sourcegraph-word-count for an example extension that uses this new API.

Depend on https://github.com/sourcegraph/sourcegraph-extension-api/pull/109.