### PR TITLE
Revert "feat: remove client settings"

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,6 +5,11 @@ import { parseJSONCOrError } from './util'
 
 export type ID = string
 
+export interface IClient {
+    __typename: 'Client'
+    displayName: string
+}
+
 /**
  * A subset of the settings JSON Schema type containing the minimum needed by this library.
  */
@@ -25,6 +30,7 @@ export interface Settings {
  */
 export type ConfigurationSubject = Pick<GQL.IConfigurationSubject, 'id' | 'settingsURL' | 'viewerCanAdminister'> &
     (
+        | Pick<IClient, '__typename' | 'displayName'>
         | Pick<GQL.IUser, '__typename' | 'username' | 'displayName'>
         | Pick<GQL.IOrg, '__typename' | 'name' | 'displayName'>
         | Pick<GQL.ISite, '__typename'>)
@@ -213,10 +219,12 @@ export function merge(base: any, add: any, custom?: CustomMergeFunctions): void 
 /**
  * The conventional ordering of extension configuration subject types in a list.
  */
-export const SUBJECT_TYPE_ORDER: ConfigurationSubject['__typename'][] = ['User', 'Org', 'Site']
+export const SUBJECT_TYPE_ORDER: ConfigurationSubject['__typename'][] = ['Client', 'User', 'Org', 'Site']
 
 export function subjectTypeHeader(nodeType: ConfigurationSubject['__typename']): string | null {
     switch (nodeType) {
+        case 'Client':
+            return null
         case 'Site':
             return null
         case 'Org':
@@ -228,6 +236,8 @@ export function subjectTypeHeader(nodeType: ConfigurationSubject['__typename']):
 
 export function subjectLabel(subject: ConfigurationSubject): string {
     switch (subject.__typename) {
+        case 'Client':
+            return 'Client'
         case 'Site':
             return 'Everyone'
         case 'Org':


### PR DESCRIPTION
This partially reverts commit 2872f622ddca3cef4dc88b230267ce61af704e87.

@slimsag was right about this. I am bringing this code back because it is nice for unauthed users to be able to toggle settings (eg whether to show coverage and blame), but I will make it so authed users do not ever see client settings.

I.e.,

- Unauthed: global settings > client settings
- Authed: global settings > org settings > user settings

(Previously, client settings also took effect for authed users. That was the source of most of the complexity.)